### PR TITLE
Adjust the height for item text to prevent DPI issue

### DIFF
--- a/lib-expandablebottombar/src/main/java/github/com/st235/lib_expandablebottombar/ExpandableItemViewController.kt
+++ b/lib-expandablebottombar/src/main/java/github/com/st235/lib_expandablebottombar/ExpandableItemViewController.kt
@@ -181,7 +181,7 @@ internal open class ExpandableItemViewController(
 
             val textLayoutParams = LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.MATCH_PARENT,
-                LinearLayout.LayoutParams.MATCH_PARENT
+                LinearLayout.LayoutParams.WRAP_CONTENT
             ).apply {
                 gravity = Gravity.CENTER
                 setMargins(8.toPx(), 0, 0, 0)


### PR DESCRIPTION
I was unable to replicate this issue while using a regular user app but when in
use with AOSP, I noticed an issue when adjusting font size to anything above 'Default'.

Test:
- Import aar to AOSP
- Utilize the library
- Adjust the font size to Large or above under Settings

See image to notice issue described above
- https://i.imgur.com/zm4s2mz.jpg