### PR TITLE
Fix: ExpandableBottomBar outline and elevation not being setted on Lollipop

### DIFF
--- a/lib-expandablebottombar/src/main/java/github/com/st235/lib_expandablebottombar/utils/AndroidUtils.kt
+++ b/lib-expandablebottombar/src/main/java/github/com/st235/lib_expandablebottombar/utils/AndroidUtils.kt
@@ -5,7 +5,7 @@ import android.os.Build
 typealias Scope = () -> Unit
 
 internal inline fun applyForApiLAndHigher(scope: Scope) {
-    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
         scope()
     }
 }


### PR DESCRIPTION
Hello!

While browsing the code to find possible contributions for hacktoberfest, I found out that these blocks, currently used for outline and elevations, only runs on API 22 or higher. 

Opened this PR because I think the intended behavior was to run on API 21 aswell.

Comparison of JavaActivity at API 21 (left is before and right is after):
![result](https://user-images.githubusercontent.com/8331460/96352397-3c248880-1099-11eb-9511-5b6ac80959ca.png)
 



