### PR TITLE
Update build scripts and dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     working_directory: ~/code
     docker:
       # Android the primary container
-      - image: circleci/android:api-25
+      - image: cimg/android:2023.08
     environment:
       JVM_OPTS: -Xmx1024m
     steps:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,6 +12,10 @@ android {
         versionCode 1
     }
 
+    lint {
+        baseline = file('lint-baseline.txt')
+    }
+
     buildTypes {
         release {
             minifyEnabled false

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,11 +2,13 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 33
+    namespace 'github.com.st235.expandablebottombar'
+
     defaultConfig {
-        applicationId "github.com.st235.expandablebottonbar"
+        applicationId 'github.com.st235.expandablebottombar'
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
+        compileSdk 34
         versionCode 1
     }
 
@@ -17,22 +19,22 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 }
 
 dependencies {
     implementation project(':lib-expandablebottombar')
 
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22'
 
-    implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.9.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.5.2'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.5.2'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.7.0'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.7.0'
 
     implementation 'com.squareup.picasso:picasso:2.8'
 }

--- a/app/lint-baseline.txt
+++ b/app/lint-baseline.txt
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.1.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.1.0)" variant="all" version="8.1.0">
+
+    <issue
+        id="NotificationPermission"
+        message="When targeting Android 13 or higher, posting a permission requires holding the `POST_NOTIFICATIONS` permission (usage from com.squareup.picasso.RemoteViewsAction.NotificationAction)">
+        <location
+            file="src/main/AndroidManifest.xml"/>
+    </issue>
+
+</issues>

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10'
+        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.22'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ android.useAndroidX=true
 
 GROUP=com.github.st235
 
-VERSION_CODE=164
-VERSION_NAME=1.5.2
+VERSION_CODE=165
+VERSION_NAME=1.5.3
 
 POM_DESCRIPTION=A new way to improve navigation in your app.
 POM_URL=https://github.com/st235/ExpandableBottomBar

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Jul 29 08:51:49 BST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/lib-expandablebottombar/build.gradle
+++ b/lib-expandablebottombar/build.gradle
@@ -4,15 +4,16 @@ apply plugin: 'kotlin-parcelize'
 apply from: './maven.gradle'
 
 android {
-    compileSdkVersion 33
+    namespace 'github.com.st235.lib_expandablebottombar'
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 33
+        targetSdkVersion 34
+        compileSdk 34
         versionCode project.property('VERSION_CODE') as int
         versionName project.property('VERSION_NAME')
 
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 
     }
 
@@ -33,21 +34,25 @@ android {
         }
     }
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
 }
 
 dependencies {
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22'
 
-    implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.9.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.5.2'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.7.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:4.6.1'
     testImplementation 'org.mockito:mockito-inline:4.6.1'
     testImplementation 'org.hamcrest:hamcrest-library:2.2'
-    testImplementation 'androidx.test:core:1.4.0'
+    testImplementation 'androidx.test:core:1.5.0'
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
     testImplementation 'org.robolectric:robolectric:4.8.1'
 

--- a/lib-expandablebottombar/build.gradle
+++ b/lib-expandablebottombar/build.gradle
@@ -49,11 +49,10 @@ dependencies {
     implementation 'androidx.navigation:navigation-fragment-ktx:2.7.0'
 
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.mockito:mockito-core:4.6.1'
-    testImplementation 'org.mockito:mockito-inline:4.6.1'
+    testImplementation 'org.mockito:mockito-core:5.3.1'
     testImplementation 'org.hamcrest:hamcrest-library:2.2'
     testImplementation 'androidx.test:core:1.5.0'
-    testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
+    testImplementation 'org.mockito.kotlin:mockito-kotlin:5.1.0'
     testImplementation 'org.robolectric:robolectric:4.8.1'
 
 }

--- a/lib-expandablebottombar/src/main/java/github/com/st235/lib_expandablebottombar/components/notifications/ExpandableBottomBarNotificationBadgeView.kt
+++ b/lib-expandablebottombar/src/main/java/github/com/st235/lib_expandablebottombar/components/notifications/ExpandableBottomBarNotificationBadgeView.kt
@@ -64,12 +64,10 @@ internal class ExpandableBottomBarNotificationBadgeView @JvmOverloads constructo
         viewBounds.set(0F, 0F, w.toFloat(), h.toFloat())
     }
 
-    override fun onDraw(canvas: Canvas?) {
+    override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
 
-        if (canvas != null) {
-            badgeDrawer?.draw(paint, viewBounds, canvas)
-        }
+        badgeDrawer?.draw(paint, viewBounds, canvas)
     }
 
     fun getState() = stateController.store(onSaveInstanceState())

--- a/lib-expandablebottombar/src/test/java/github/com/st235/expandablebottombar/MenuItemDescriptorTest.kt
+++ b/lib-expandablebottombar/src/test/java/github/com/st235/expandablebottombar/MenuItemDescriptorTest.kt
@@ -1,11 +1,11 @@
 package github.com.st235.expandablebottombar
 
 import android.content.Context
-import com.nhaarman.mockitokotlin2.mock
 import github.com.st235.lib_expandablebottombar.MenuItemDescriptor
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import org.mockito.kotlin.mock
 
 @RunWith(JUnit4::class)
 class MenuItemDescriptorTest {

--- a/lib-expandablebottombar/src/test/java/github/com/st235/expandablebottombar/MenuItemFactoryTest.kt
+++ b/lib-expandablebottombar/src/test/java/github/com/st235/expandablebottombar/MenuItemFactoryTest.kt
@@ -1,28 +1,25 @@
 package github.com.st235.expandablebottombar
 
 import android.content.Context
-import android.content.res.ColorStateList
-import android.graphics.drawable.ColorStateListDrawable
 import android.view.View
 import androidx.test.core.app.ApplicationProvider
-import com.nhaarman.mockitokotlin2.anyOrNull
-import github.com.st235.lib_expandablebottombar.test.R
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
 import github.com.st235.lib_expandablebottombar.ExpandableBottomBar
 import github.com.st235.lib_expandablebottombar.MenuItem
 import github.com.st235.lib_expandablebottombar.MenuItemDescriptor
 import github.com.st235.lib_expandablebottombar.MenuItemFactory
 import github.com.st235.lib_expandablebottombar.components.MenuItemView
-import github.com.st235.lib_expandablebottombar.utils.DrawableHelper
+import github.com.st235.lib_expandablebottombar.test.R
 import github.com.st235.lib_expandablebottombar.utils.StyleController
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.*
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
-import java.lang.reflect.Field
-import java.lang.reflect.Modifier
 
 @RunWith(RobolectricTestRunner::class)
 class MenuItemFactoryTest {
@@ -31,8 +28,6 @@ class MenuItemFactoryTest {
     private val rootView = mock<ExpandableBottomBar>()
     private val styleController = mock<StyleController>()
     private val onItemClick = mock<(MenuItem, View) -> Unit>()
-    private val colorStateList = mock<ColorStateList>()
-    private val drawableHelper = mockObject(DrawableHelper::class.java)
 
     private val itemVerticalPadding: Int = 54
     private val itemHorizontalPadding: Int = 61
@@ -80,7 +75,6 @@ class MenuItemFactoryTest {
     @Before
     fun setUp() {
         whenever(rootView.context).thenReturn(ApplicationProvider.getApplicationContext())
-        doAnswer{ colorStateList }.whenever(drawableHelper).createSelectedUnselectedStateList(anyInt(), anyInt())
     }
 
     @Test
@@ -89,8 +83,8 @@ class MenuItemFactoryTest {
 
         verify(itemView, times(1)).id = menuItemDescriptorWithoutNotificationInfo.itemId
         verify(itemView, times(1)).setPadding(itemHorizontalPadding, itemVerticalPadding, itemHorizontalPadding, itemVerticalPadding)
-        verify(itemView, times(1)).setIcon(menuItemDescriptorWithoutNotificationInfo.iconId, colorStateList)
-        verify(itemView, times(1)).setText(menuItemDescriptorWithoutNotificationInfo.text, colorStateList)
+        verify(itemView, times(1)).setIcon(eq(menuItemDescriptorWithoutNotificationInfo.iconId), anyOrNull())
+        verify(itemView, times(1)).setText(eq(menuItemDescriptorWithoutNotificationInfo.text), anyOrNull())
         verify(itemView, times(1)).notificationBadgeBackgroundColor = globalNotificationBadgeColor
         verify(itemView, times(1)).notificationBadgeTextColor = globalNotificationBadgeTextColor
     }
@@ -101,41 +95,9 @@ class MenuItemFactoryTest {
 
         verify(itemView, times(1)).id = menuItemDescriptorWithNotificationInfo.itemId
         verify(itemView, times(1)).setPadding(itemHorizontalPadding, itemVerticalPadding, itemHorizontalPadding, itemVerticalPadding)
-        verify(itemView, times(1)).setIcon(menuItemDescriptorWithNotificationInfo.iconId, colorStateList)
-        verify(itemView, times(1)).setText(menuItemDescriptorWithNotificationInfo.text, colorStateList)
+        verify(itemView, times(1)).setIcon(eq(menuItemDescriptorWithNotificationInfo.iconId), anyOrNull())
+        verify(itemView, times(1)).setText(eq(menuItemDescriptorWithNotificationInfo.text), anyOrNull())
         verify(itemView, times(1)).notificationBadgeBackgroundColor = menuItemDescriptorWithNotificationInfo.badgeBackgroundColor!!
         verify(itemView, times(1)).notificationBadgeTextColor = menuItemDescriptorWithNotificationInfo.badgeTextColor!!
-    }
-
-    private fun <T> mockObject(clazz: Class<T>): T {
-        val constructor = clazz.declaredConstructors.find { it.parameterCount == 0 }
-            ?: throw InstantiationException("class ${clazz.canonicalName} has no empty constructor, " +
-                    "is it really a Kotlin \"object\"?")
-
-        constructor.isAccessible = true
-
-        val mockedInstance = spy(constructor.newInstance() as T)
-
-        return replaceObjectInstance(clazz, mockedInstance)
-    }
-
-    private fun <T> replaceObjectInstance(clazz: Class<T>, newInstance: T): T {
-
-        if (!clazz.declaredFields.any {
-                it.name == "INSTANCE" && it.type == clazz && Modifier.isStatic(it.modifiers)
-            }) {
-            throw InstantiationException("clazz ${clazz.canonicalName} does not have a static  " +
-                    "INSTANCE field, is it really a Kotlin \"object\"?")
-        }
-
-        val instanceField = clazz.getDeclaredField("INSTANCE")
-        val modifiersField = Field::class.java.getDeclaredField("modifiers")
-        modifiersField.isAccessible = true
-        modifiersField.setInt(instanceField, instanceField.modifiers and Modifier.FINAL.inv())
-
-        instanceField.isAccessible = true
-        val originalInstance = instanceField.get(null) as T
-        instanceField.set(null, newInstance)
-        return newInstance
     }
 }

--- a/lib-expandablebottombar/src/test/java/github/com/st235/expandablebottombar/MenuItemImplTest.kt
+++ b/lib-expandablebottombar/src/test/java/github/com/st235/expandablebottombar/MenuItemImplTest.kt
@@ -2,7 +2,6 @@ package github.com.st235.expandablebottombar
 
 import android.view.View
 import androidx.constraintlayout.widget.ConstraintLayout
-import com.nhaarman.mockitokotlin2.*
 import github.com.st235.lib_expandablebottombar.ExpandableBottomBar
 import github.com.st235.lib_expandablebottombar.Menu
 import github.com.st235.lib_expandablebottombar.MenuItemDescriptor
@@ -10,11 +9,19 @@ import github.com.st235.lib_expandablebottombar.MenuItemImpl
 import github.com.st235.lib_expandablebottombar.components.MenuItemView
 import github.com.st235.lib_expandablebottombar.utils.ConstraintLayoutHelper
 import github.com.st235.lib_expandablebottombar.utils.TransitionHelper
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 @RunWith(JUnit4::class)
 class MenuItemImplTest {

--- a/lib-expandablebottombar/src/test/java/github/com/st235/expandablebottombar/NotificationTest.kt
+++ b/lib-expandablebottombar/src/test/java/github/com/st235/expandablebottombar/NotificationTest.kt
@@ -1,16 +1,16 @@
 package github.com.st235.expandablebottombar
 
 import android.graphics.Color
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.times
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import github.com.st235.lib_expandablebottombar.Notification
 import github.com.st235.lib_expandablebottombar.NotificationBadge
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 @RunWith(JUnit4::class)
 class NotificationTest {


### PR DESCRIPTION
* Bump Gradle Android plugin from 7.2.2 -> 8.1.0
* Bump Gradle version 7.5 -> 8.1
* Bump Kotlin Gradle plugin and std 1.7.10 -> 1.8.22
* Bump 3rd party dependencies
* Add namespace to build script
* Replace deprecated compileSdkVersion with defaultConfig.compileSdk
* Bump target and compile sdk 33 -> 34
* Add target and source compatibility with jdk 17
* Support new nullability information for View#onDraw in ExpandableBottomBarNotificationBadgeView