### PR TITLE
Remove package name from the Manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="github.com.st235.expandablebottombar">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
             android:allowBackup="false"

--- a/lib-expandablebottombar/src/main/AndroidManifest.xml
+++ b/lib-expandablebottombar/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="github.com.st235.lib_expandablebottombar"/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />


### PR DESCRIPTION
Fixing the Gradle warning

```
package="github.com.st235.expandablebottombar" found in source AndroidManifest.xml: /Users/alexanderdadukin/Documents/Android/ExpandableBottomBar/app/src/main/AndroidManifest.xml.
Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported, and the value is ignored.
Recommendation: remove package="github.com.st235.expandablebottombar" from the source AndroidManifest.xml: /Users/alexanderdadukin/Documents/Android/ExpandableBottomBar/app/src/main/AndroidManifest.xml.
```