### PR TITLE
Refactor: Replace findViewById with ViewBinding in ExpandableBottomBar examples

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,6 +26,10 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+
+    buildFeatures {
+        viewBinding = true
+    }
 }
 
 dependencies {

--- a/app/src/main/java/github/com/st235/expandablebottombar/ShowCaseActivity.kt
+++ b/app/src/main/java/github/com/st235/expandablebottombar/ShowCaseActivity.kt
@@ -3,9 +3,8 @@ package github.com.st235.expandablebottombar
 import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.widget.Toolbar
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
+import github.com.st235.expandablebottombar.databinding.ActivityShowcaseBinding
 import github.com.st235.expandablebottombar.screens.*
 import github.com.st235.expandablebottombar.screens.navigation.NavigationComponentActivity
 
@@ -48,28 +47,26 @@ class ShowCaseActivity : AppCompatActivity() {
         )
     }
 
-    private lateinit var toolbar: Toolbar
-    private lateinit var recyclerView: RecyclerView
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_showcase)
 
-        toolbar = findViewById(R.id.toolbar)
-        recyclerView = findViewById(R.id.recyclerView)
+        val binding = ActivityShowcaseBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        setSupportActionBar(toolbar)
+        with(binding) {
+            setSupportActionBar(toolbar)
 
-        val adapter = ShowCaseAdapter(showCaseInfos) { info ->
-            val intent = Intent(this@ShowCaseActivity, info.toClass)
-            intent.putExtra(ARGS_SCREEN_TITLE, title)
-            startActivity(intent)
+            val adapter = ShowCaseAdapter(showCaseInfos) { info ->
+                val intent = Intent(this@ShowCaseActivity, info.toClass)
+                intent.putExtra(ARGS_SCREEN_TITLE, title)
+                startActivity(intent)
+            }
+
+            val layoutManager = LinearLayoutManager(this@ShowCaseActivity)
+
+            recyclerView.adapter = adapter
+            recyclerView.layoutManager = layoutManager
         }
-
-        val layoutManager = LinearLayoutManager(this)
-
-        recyclerView.adapter = adapter
-        recyclerView.layoutManager = layoutManager
     }
 
     companion object {

--- a/app/src/main/java/github/com/st235/expandablebottombar/ShowCaseAdapter.kt
+++ b/app/src/main/java/github/com/st235/expandablebottombar/ShowCaseAdapter.kt
@@ -4,8 +4,8 @@ import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
+import github.com.st235.expandablebottombar.databinding.ContentShowcaseItemBinding
 
 typealias OnItemClickListener = (info: ShowCaseInfo) -> Unit
 
@@ -16,7 +16,7 @@ class ShowCaseAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val context = parent.context
-        val v = LayoutInflater.from(context).inflate(R.layout.content_showcase_item, parent, false)
+        val v = ContentShowcaseItemBinding.inflate(LayoutInflater.from(context), parent, false)
         return ViewHolder(v)
     }
 
@@ -26,21 +26,18 @@ class ShowCaseAdapter(
 
     override fun getItemCount(): Int = items.size
 
-    inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView), View.OnClickListener {
-        val title: TextView = itemView.findViewById(R.id.title)
-        val description: TextView = itemView.findViewById(R.id.description)
-
+    inner class ViewHolder(private val binding: ContentShowcaseItemBinding) :RecyclerView.ViewHolder(binding.root), View.OnClickListener {
         init {
             itemView.isClickable = true
             itemView.isFocusable = true
             itemView.setOnClickListener(this)
 
-            description.movementMethod = LinkMovementMethod.getInstance()
+            binding.description.movementMethod = LinkMovementMethod.getInstance()
         }
 
         fun bind(showCaseInfo: ShowCaseInfo) {
-            title.text = showCaseInfo.title
-            description.text = showCaseInfo.description
+            binding.title.text = showCaseInfo.title
+            binding.description.text = showCaseInfo.description
         }
 
         override fun onClick(v: View?) {

--- a/app/src/main/java/github/com/st235/expandablebottombar/screens/CoordinatorLayoutActivity.kt
+++ b/app/src/main/java/github/com/st235/expandablebottombar/screens/CoordinatorLayoutActivity.kt
@@ -2,24 +2,21 @@ package github.com.st235.expandablebottombar.screens
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.snackbar.Snackbar
-import github.com.st235.expandablebottombar.R
+import github.com.st235.expandablebottombar.databinding.ActivityCoordinatorLayoutBinding
 
 class CoordinatorLayoutActivity : AppCompatActivity() {
 
-    private lateinit var fab: FloatingActionButton
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_coordinator_layout)
 
+        val binding = ActivityCoordinatorLayoutBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        fab = findViewById(R.id.fab)
-
-        fab.setOnClickListener { view ->
-            Snackbar.make(view, "Meow", Snackbar.LENGTH_LONG).show()
+        with(binding) {
+            fab.setOnClickListener { view ->
+                Snackbar.make(view, "Meow", Snackbar.LENGTH_LONG).show()
+            }
         }
     }
-
 }

--- a/app/src/main/java/github/com/st235/expandablebottombar/screens/JavaActivity.java
+++ b/app/src/main/java/github/com/st235/expandablebottombar/screens/JavaActivity.java
@@ -7,9 +7,8 @@ import android.util.Log;
 import androidx.appcompat.app.AppCompatActivity;
 
 import github.com.st235.expandablebottombar.R;
-import github.com.st235.lib_expandablebottombar.ExpandableBottomBar;
+import github.com.st235.expandablebottombar.databinding.ActivityJavaBinding;
 import github.com.st235.lib_expandablebottombar.Menu;
-import github.com.st235.lib_expandablebottombar.MenuItem;
 import github.com.st235.lib_expandablebottombar.MenuItemDescriptor;
 
 public class JavaActivity extends AppCompatActivity {
@@ -19,10 +18,11 @@ public class JavaActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_java);
 
-        ExpandableBottomBar bottomBar = findViewById(R.id.expandable_bottom_bar);
-        Menu menu = bottomBar.getMenu();
+        ActivityJavaBinding binding = ActivityJavaBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
+
+        Menu menu = binding.expandableBottomBar.getMenu();
 
         menu.add(
                 new MenuItemDescriptor.Builder(this, R.id.icon_home, R.drawable.ic_home, R.string.text, Color.GRAY).build()
@@ -40,12 +40,12 @@ public class JavaActivity extends AppCompatActivity {
                 new MenuItemDescriptor.Builder(this, R.id.icon_settings, R.drawable.ic_settings, R.string.text4, 0xffbe9c91).build()
         );
 
-        bottomBar.setOnItemSelectedListener((view, item, byUser) -> {
+        binding.expandableBottomBar.setOnItemSelectedListener((view, item, byUser) -> {
             Log.d(TAG, "selected: " + item.toString());
             return null;
         });
 
-        bottomBar.setOnItemReselectedListener((view, item, byUser) -> {
+        binding.expandableBottomBar.setOnItemReselectedListener((view, item, byUser) -> {
             Log.d(TAG, "reselected: " + item.toString());
             return null;
         });

--- a/app/src/main/java/github/com/st235/expandablebottombar/screens/NotificationBadgeActivity.kt
+++ b/app/src/main/java/github/com/st235/expandablebottombar/screens/NotificationBadgeActivity.kt
@@ -7,49 +7,46 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewAnimationUtils
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.widget.Toolbar
 import androidx.core.graphics.ColorUtils
 import github.com.st235.expandablebottombar.R
-import github.com.st235.lib_expandablebottombar.ExpandableBottomBar
+import github.com.st235.expandablebottombar.databinding.ActivityNotificationBadgeBinding
 
 class NotificationBadgeActivity : AppCompatActivity() {
 
-    private lateinit var toolbar: Toolbar
-    private lateinit var bottomBar: ExpandableBottomBar
+    private lateinit var binding: ActivityNotificationBadgeBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_notification_badge)
 
-        toolbar = findViewById(R.id.toolbar)
+        binding = ActivityNotificationBadgeBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        setSupportActionBar(toolbar)
+        with(binding) {
+            setSupportActionBar(toolbar)
 
-        val color: View = findViewById(R.id.color)
-        bottomBar = findViewById(R.id.expandable_bottom_bar)
+            color.setBackgroundColor(ColorUtils.setAlphaComponent(Color.GRAY, 60))
 
-        color.setBackgroundColor(ColorUtils.setAlphaComponent(Color.GRAY, 60))
-
-        bottomBar.onItemSelectedListener = { v, i, _ ->
-            val anim = ViewAnimationUtils.createCircularReveal(color,
-                    bottomBar.x.toInt() + v.x.toInt() + v.width / 2,
-                    bottomBar.y.toInt() + v.y.toInt() + v.height / 2, 0F,
+            expandableBottomBar.onItemSelectedListener = { v, i, _ ->
+                val anim = ViewAnimationUtils.createCircularReveal(color,
+                    expandableBottomBar.x.toInt() + v.x.toInt() + v.width / 2,
+                    expandableBottomBar.y.toInt() + v.y.toInt() + v.height / 2, 0F,
                     findViewById<View>(android.R.id.content).height.toFloat())
-            color.setBackgroundColor(ColorUtils.setAlphaComponent(i.activeColor, 60))
-            anim.duration = 420
-            anim.start()
-        }
+                color.setBackgroundColor(ColorUtils.setAlphaComponent(i.activeColor, 60))
+                anim.duration = 420
+                anim.start()
+            }
 
-        bottomBar.onItemReselectedListener = { v, i, _ ->
-            val notification = i.notification()
+            expandableBottomBar.onItemReselectedListener = { v, i, _ ->
+                val notification = i.notification()
 
-            if (v.tag == null) {
-                notification.show()
-                v.tag = 0
-            } else {
-                val counter = (v.tag as Int) + 1
-                notification.show(counter.toString())
-                v.tag = counter
+                if (v.tag == null) {
+                    notification.show()
+                    v.tag = 0
+                } else {
+                    val counter = (v.tag as Int) + 1
+                    notification.show(counter.toString())
+                    v.tag = counter
+                }
             }
         }
     }
@@ -62,7 +59,7 @@ class NotificationBadgeActivity : AppCompatActivity() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             R.id.clear -> {
-                for (menuItem in bottomBar.menu) {
+                for (menuItem in binding.expandableBottomBar.menu) {
                     menuItem.notification().clear()
                 }
             }

--- a/app/src/main/java/github/com/st235/expandablebottombar/screens/ProgrammaticallyCreatedDemoActivity.kt
+++ b/app/src/main/java/github/com/st235/expandablebottombar/screens/ProgrammaticallyCreatedDemoActivity.kt
@@ -8,9 +8,8 @@ import android.view.ViewAnimationUtils
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.graphics.ColorUtils
 import github.com.st235.expandablebottombar.R
-import github.com.st235.lib_expandablebottombar.ExpandableBottomBar
+import github.com.st235.expandablebottombar.databinding.ActivityProgrammaticallyDeclaredBinding
 import github.com.st235.lib_expandablebottombar.MenuItemDescriptor
-
 
 class ProgrammaticallyCreatedDemoActivity : AppCompatActivity() {
 
@@ -18,70 +17,72 @@ class ProgrammaticallyCreatedDemoActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_programmatically_declared)
 
-        val colorView: View = findViewById(R.id.color)
-        val bottomBar: ExpandableBottomBar = findViewById(R.id.expandable_bottom_bar)
+        val binding = ActivityProgrammaticallyDeclaredBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        colorView.setBackgroundColor(ColorUtils.setAlphaComponent(Color.GRAY, 60))
+        with(binding) {
+            color.setBackgroundColor(ColorUtils.setAlphaComponent(Color.GRAY, 60))
 
-        val menu = bottomBar.menu
+            val menu = expandableBottomBar.menu
 
-        menu.add(
-            MenuItemDescriptor.Builder(
-                this,
-                R.id.icon_home,
-                R.drawable.ic_home,
-                R.string.text, Color.GRAY
+            menu.add(
+                MenuItemDescriptor.Builder(
+                    this@ProgrammaticallyCreatedDemoActivity,
+                    R.id.icon_home,
+                    R.drawable.ic_home,
+                    R.string.text, Color.GRAY
+                )
+                    .build()
             )
-                .build()
-        )
 
-        menu.add(
-            MenuItemDescriptor.Builder(
-                this,
-                R.id.icon_likes,
-                R.drawable.ic_likes
+            menu.add(
+                MenuItemDescriptor.Builder(
+                    this@ProgrammaticallyCreatedDemoActivity,
+                    R.id.icon_likes,
+                    R.drawable.ic_likes
+                )
+                    .textRes(R.string.text2)
+                    .colorRes(R.color.colorLike)
+                    .build()
             )
-                .textRes(R.string.text2)
-                .colorRes(R.color.colorLike)
-                .build()
-        )
 
-        menu.add(
-            MenuItemDescriptor.Builder(
-                this,
-                R.id.icon_bookmarks,
-                R.drawable.ic_bookmarks,
-                R.string.text3,
-                Color.parseColor("#58a5f0")
+            menu.add(
+                MenuItemDescriptor.Builder(
+                    this@ProgrammaticallyCreatedDemoActivity,
+                    R.id.icon_bookmarks,
+                    R.drawable.ic_bookmarks,
+                    R.string.text3,
+                    Color.parseColor("#58a5f0")
+                )
+                    .build()
             )
-                .build()
-        )
 
-        menu.add(
-            MenuItemDescriptor.Builder(
-                this,
-                R.id.icon_settings,
-                R.drawable.ic_settings,
-                R.string.text4,
-                Color.parseColor("#be9c91")
+            menu.add(
+                MenuItemDescriptor.Builder(
+                    this@ProgrammaticallyCreatedDemoActivity,
+                    R.id.icon_settings,
+                    R.drawable.ic_settings,
+                    R.string.text4,
+                    Color.parseColor("#be9c91")
+                )
+                    .build()
             )
-                .build()
-        )
 
-        bottomBar.onItemSelectedListener = { v, i, _ ->
-            val anim = ViewAnimationUtils.createCircularReveal(
-                colorView,
-                bottomBar.x.toInt() + v.x.toInt() + v.width / 2,
-                bottomBar.y.toInt() + v.y.toInt() + v.height / 2, 0F,
-                findViewById<View>(android.R.id.content).height.toFloat()
-            )
-            colorView.setBackgroundColor(ColorUtils.setAlphaComponent(i.activeColor, 60))
-            anim.duration = 420
-            anim.start()
-        }
+            expandableBottomBar.onItemSelectedListener = { v, i, _ ->
+                val anim = ViewAnimationUtils.createCircularReveal(
+                    color,
+                    expandableBottomBar.x.toInt() + v.x.toInt() + v.width / 2,
+                    expandableBottomBar.y.toInt() + v.y.toInt() + v.height / 2, 0F,
+                    findViewById<View>(android.R.id.content).height.toFloat()
+                )
+                color.setBackgroundColor(ColorUtils.setAlphaComponent(i.activeColor, 60))
+                anim.duration = 420
+                anim.start()
+            }
 
-        bottomBar.onItemReselectedListener = { _, i, _ ->
-            Log.d("ExpandableBottomBar", "OnReselected: ${i.id}")
+            expandableBottomBar.onItemReselectedListener = { _, i, _ ->
+                Log.d("ExpandableBottomBar", "OnReselected: ${i.id}")
+            }
         }
     }
 }

--- a/app/src/main/java/github/com/st235/expandablebottombar/screens/ScrollableCoordinatorLayoutActivity.kt
+++ b/app/src/main/java/github/com/st235/expandablebottombar/screens/ScrollableCoordinatorLayoutActivity.kt
@@ -3,7 +3,6 @@ package github.com.st235.expandablebottombar.screens
 import android.graphics.BitmapFactory
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.DrawableRes
 import androidx.annotation.WorkerThread
@@ -11,31 +10,29 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.snackbar.Snackbar
 import com.squareup.picasso.Picasso
 import github.com.st235.expandablebottombar.R
-import java.util.concurrent.Executors
+import github.com.st235.expandablebottombar.databinding.ActivityScrollableCoordinatorLayoutBinding
+import github.com.st235.expandablebottombar.databinding.ItemCatBinding
 
 class ScrollableCoordinatorLayoutActivity : AppCompatActivity() {
 
-    private lateinit var fab: FloatingActionButton
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_scrollable_coordinator_layout)
 
-        fab = findViewById(R.id.fab)
+        val binding = ActivityScrollableCoordinatorLayoutBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        val rc = findViewById<RecyclerView>(R.id.recycler_view)
+        with(binding) {
+            recyclerView.apply {
+                layoutManager = GridLayoutManager(context, 2)
+                adapter = Adapter()
+            }
 
-        rc.apply {
-            layoutManager = GridLayoutManager(context, 2)
-            adapter = Adapter()
-        }
-
-        fab.setOnClickListener { view ->
-            Snackbar.make(view, "Meow", Snackbar.LENGTH_LONG).show()
+            fab.setOnClickListener { view ->
+                Snackbar.make(view, "Meow", Snackbar.LENGTH_LONG).show()
+            }
         }
     }
 
@@ -66,15 +63,10 @@ class ScrollableCoordinatorLayoutActivity : AppCompatActivity() {
         return inSampleSize
     }
 
-    private inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-
-        private val image = itemView.findViewById<AppCompatImageView>(R.id.item_iv)
-
+    private inner class ViewHolder(val binding: ItemCatBinding) : RecyclerView.ViewHolder(binding.root) {
         fun setResource(@DrawableRes id: Int) {
-            loadBitmap(id, image)
+            loadBitmap(id, binding.itemIv)
         }
-
-
     }
 
     private inner class Adapter : RecyclerView.Adapter<ViewHolder>() {
@@ -92,7 +84,7 @@ class ScrollableCoordinatorLayoutActivity : AppCompatActivity() {
 
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
             val ctx = parent.context
-            val v = LayoutInflater.from(ctx).inflate(R.layout.item_cat, parent, false)
+            val v = ItemCatBinding.inflate(LayoutInflater.from(ctx), parent, false)
             return ViewHolder(v)
         }
 

--- a/app/src/main/java/github/com/st235/expandablebottombar/screens/XmlDeclaredActivity.kt
+++ b/app/src/main/java/github/com/st235/expandablebottombar/screens/XmlDeclaredActivity.kt
@@ -6,36 +6,32 @@ import android.view.Menu
 import android.view.View
 import android.view.ViewAnimationUtils
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.widget.Toolbar
 import androidx.core.graphics.ColorUtils
 import github.com.st235.expandablebottombar.R
-import github.com.st235.lib_expandablebottombar.ExpandableBottomBar
+import github.com.st235.expandablebottombar.databinding.ActivityXmlDeclaredBinding
 
 class XmlDeclaredActivity : AppCompatActivity() {
 
-    private lateinit var toolbar: Toolbar
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_xml_declared)
 
-        toolbar = findViewById(R.id.toolbar)
+        val binding = ActivityXmlDeclaredBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        setSupportActionBar(toolbar)
+        with(binding) {
+            setSupportActionBar(toolbar)
 
-        val color: View = findViewById(R.id.color)
-        val bottomBar: ExpandableBottomBar = findViewById(R.id.expandable_bottom_bar)
+            color.setBackgroundColor(ColorUtils.setAlphaComponent(Color.GRAY, 60))
 
-        color.setBackgroundColor(ColorUtils.setAlphaComponent(Color.GRAY, 60))
-
-        bottomBar.onItemSelectedListener = { v, i, _ ->
-            val anim = ViewAnimationUtils.createCircularReveal(color,
-                    bottomBar.x.toInt() + v.x.toInt() + v.width / 2,
-                    bottomBar.y.toInt() + v.y.toInt() + v.height / 2, 0F,
+            expandableBottomBar.onItemSelectedListener = { v, i, _ ->
+                val anim = ViewAnimationUtils.createCircularReveal(color,
+                    expandableBottomBar.x.toInt() + v.x.toInt() + v.width / 2,
+                    expandableBottomBar.y.toInt() + v.y.toInt() + v.height / 2, 0F,
                     findViewById<View>(android.R.id.content).height.toFloat())
-            color.setBackgroundColor(ColorUtils.setAlphaComponent(i.activeColor, 60))
-            anim.duration = 420
-            anim.start()
+                color.setBackgroundColor(ColorUtils.setAlphaComponent(i.activeColor, 60))
+                anim.duration = 420
+                anim.start()
+            }
         }
     }
 


### PR DESCRIPTION
Hello!

While using the ExpandableBottomBar library in this project, I noticed that the examples were heavily relying on findViewById. This method can lead to potential errors and affect the code readability. 

To improve this, I refactored the examples to use ViewBinding in 'mybranch'. ViewBinding ensures type safety and null safety, which can reduce potential errors and improve readability.

While there was no open issue regarding this, I believe this change could significantly improve the overall quality of the examples provided with the library.

Although I do not have any comparison images, I can assure you that the change has made the examples more concise and safer by preventing potential null pointer exceptions. 

Thank you for considering this contribution.
