### PR TITLE
Add new layout attribute to control text size

### DIFF
--- a/app/src/main/res/layout/activity_xml_declared.xml
+++ b/app/src/main/res/layout/activity_xml_declared.xml
@@ -27,6 +27,7 @@
         android:layout_height="wrap_content"
         app:exb_items="@menu/bottom_bar"
         app:exb_itemInactiveColor="#CCCCCC"
+        app:exb_textSize="16sp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/expandablebottombar/src/main/java/github/com/st235/expandablebottombar/ExpandableBottomBar.kt
+++ b/expandablebottombar/src/main/java/github/com/st235/expandablebottombar/ExpandableBottomBar.kt
@@ -18,9 +18,11 @@ import androidx.annotation.ColorRes
 import androidx.annotation.DimenRes
 import androidx.annotation.FloatRange
 import androidx.annotation.IntRange
+import androidx.annotation.RequiresApi
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
+import androidx.core.content.res.getFloatOrThrow
 import androidx.core.view.ViewCompat
 import androidx.core.view.marginBottom
 import github.com.st235.expandablebottombar.ExpandableBottomBar.ItemStyle.Companion.toItemStyle
@@ -171,6 +173,12 @@ class ExpandableBottomBar @JvmOverloads constructor(
         backgroundCornerRadius =
             typedArray.getDimension(R.styleable.ExpandableBottomBar_exb_backgroundCornerRadius, 0F)
 
+        val textSize = if (typedArray.hasValue(R.styleable.ExpandableBottomBar_exb_textSize)) {
+            typedArray.getDimension(R.styleable.ExpandableBottomBar_exb_textSize, 0F)
+        } else {
+            null
+        }
+
         background =
             DrawableHelper.createShapeDrawable(
                 color = backgroundColor,
@@ -193,7 +201,8 @@ class ExpandableBottomBar @JvmOverloads constructor(
             itemBackgroundCornerRadius,
             itemBackgroundOpacity,
             itemInactiveColor, globalBadgeColor,
-            globalBadgeTextColor
+            globalBadgeTextColor,
+            textSize,
         )
         menuImpl = MenuImpl(
             this,
@@ -342,7 +351,7 @@ class ExpandableBottomBar @JvmOverloads constructor(
         }
     }
 
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     private inner class ExpandableBottomBarOutlineProvider : ViewOutlineProvider() {
         override fun getOutline(view: View?, outline: Outline?) {
             outline?.setRoundRect(

--- a/expandablebottombar/src/main/java/github/com/st235/expandablebottombar/MenuItemFactory.kt
+++ b/expandablebottombar/src/main/java/github/com/st235/expandablebottombar/MenuItemFactory.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.drawable.Drawable
 import android.view.View
 import androidx.annotation.ColorInt
+import androidx.annotation.Dimension
 import androidx.annotation.FloatRange
 import androidx.annotation.Px
 import androidx.annotation.VisibleForTesting
@@ -15,12 +16,13 @@ internal open class MenuItemFactory @Suppress("LongParameterList") constructor(
     private val rootView: ExpandableBottomBar,
     private val styleController: StyleController,
     @Px private val itemVerticalPadding: Int,
-    @Px private var itemHorizontalPadding: Int,
-    @Px private var backgroundCornerRadius: Float,
-    @FloatRange(from = 0.0, to = 1.0) private var backgroundOpacity: Float,
-    @ColorInt private var itemInactiveColor: Int,
-    @ColorInt private var globalNotificationBadgeColor: Int,
-    @ColorInt private var globalNotificationBadgeTextColor: Int
+    @Px private val itemHorizontalPadding: Int,
+    @Px private val backgroundCornerRadius: Float,
+    @FloatRange(from = 0.0, to = 1.0) private val backgroundOpacity: Float,
+    @ColorInt private val itemInactiveColor: Int,
+    @ColorInt private val globalNotificationBadgeColor: Int,
+    @ColorInt private val globalNotificationBadgeTextColor: Int,
+    @param:Dimension(Dimension.PX) private val textSize: Float? = null,
 ) {
 
     fun build(
@@ -58,7 +60,13 @@ internal open class MenuItemFactory @Suppress("LongParameterList") constructor(
                 menuItemDescriptor.iconId,
                 backgroundColorStateList
             )
-            setText(menuItemDescriptor.text, backgroundColorStateList)
+            setText(
+                text = menuItemDescriptor.text,
+                style = MenuItemView.TextStyle(
+                    backgroundColor = backgroundColorStateList,
+                    size = textSize,
+                )
+            )
             notificationBadgeBackgroundColor =
                 menuItemDescriptor.badgeBackgroundColor ?: globalNotificationBadgeColor
             notificationBadgeTextColor =

--- a/expandablebottombar/src/main/java/github/com/st235/expandablebottombar/components/MenuItemView.kt
+++ b/expandablebottombar/src/main/java/github/com/st235/expandablebottombar/components/MenuItemView.kt
@@ -4,10 +4,11 @@ import android.content.Context
 import android.content.res.ColorStateList
 import android.os.Parcelable
 import android.util.AttributeSet
+import android.util.TypedValue
 import android.view.Gravity
-import android.view.View
 import android.widget.LinearLayout
 import androidx.annotation.ColorInt
+import androidx.annotation.Dimension
 import androidx.annotation.DrawableRes
 import androidx.appcompat.widget.AppCompatTextView
 import github.com.st235.expandablebottombar.NotificationBadge
@@ -21,6 +22,11 @@ private const val DEFAULT_NOTIFICATION_TEXT_LENGTH = 4
 internal class MenuItemView @JvmOverloads constructor(
     context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
 ) : LinearLayout(context, attrs, defStyleAttr), NotificationBadge {
+
+    data class TextStyle(
+        val backgroundColor: ColorStateList,
+        @param:Dimension(unit = Dimension.PX) val size: Float? = null,
+    )
 
     private val iconView: ExpandableBottomBarNotificationBadgeView
     private val titleView: AppCompatTextView
@@ -77,13 +83,16 @@ internal class MenuItemView @JvmOverloads constructor(
         )
     }
 
-    fun setText(text: CharSequence, textColorSelector: ColorStateList) {
+    fun setText(text: CharSequence, style: TextStyle) {
         titleView.text = text
-        titleView.setTextColor(textColorSelector)
+        titleView.setTextColor(style.backgroundColor)
+        style.size?.let {
+            titleView.setTextSize(TypedValue.COMPLEX_UNIT_PX, it)
+        }
     }
 
     fun select() {
-        titleView.visibility = View.VISIBLE
+        titleView.visibility = VISIBLE
         titleView.isSelected = true
         iconView.isSelected = true
         isSelected = true

--- a/expandablebottombar/src/main/res/values/attrs.xml
+++ b/expandablebottombar/src/main/res/values/attrs.xml
@@ -32,6 +32,8 @@
 
         <attr name="exb_notificationBadgeBackgroundColor" format="color" />
         <attr name="exb_notificationBadgeTextColor" format="color" />
+
+        <attr name="exb_textSize" format="dimension" />
     </declare-styleable>
 
     <attr name="exb_expandableButtonBarDefaultStyle" format="reference" />

--- a/expandablebottombar/src/test/java/github/com/st235/expandablebottombar/MenuItemFactoryTest.kt
+++ b/expandablebottombar/src/test/java/github/com/st235/expandablebottombar/MenuItemFactoryTest.kt
@@ -9,6 +9,7 @@ import github.com.st235.expandablebottombar.utils.StyleController
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -93,7 +94,7 @@ class MenuItemFactoryTest {
         )
         verify(itemView, times(1)).setText(
             eq(menuItemDescriptorWithoutNotificationInfo.text),
-            anyOrNull()
+            any()
         )
         verify(itemView, times(1)).notificationBadgeBackgroundColor =
             globalNotificationBadgeColor
@@ -119,7 +120,7 @@ class MenuItemFactoryTest {
         )
         verify(itemView, times(1)).setText(
             eq(menuItemDescriptorWithNotificationInfo.text),
-            anyOrNull()
+            any()
         )
         verify(itemView, times(1)).notificationBadgeBackgroundColor =
             menuItemDescriptorWithNotificationInfo.badgeBackgroundColor!!

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ android.useAndroidX=true
 
 GROUP=com.github.st235
 
-VERSION_CODE=167
-VERSION_NAME=1.6.0
+VERSION_CODE=203
+VERSION_NAME=1.6.1
 
 POM_DESCRIPTION=A new way to improve navigation in your app.
 POM_URL=https://github.com/st235/ExpandableBottomBar


### PR DESCRIPTION
Introduces new layout attribute: `exb_textSize` to control text size.

<img width="256" src="https://github.com/user-attachments/assets/e38d27de-9563-4f0c-92cc-415c8f738a64" />
